### PR TITLE
Feature/repos projects organizations

### DIFF
--- a/srcopsmetrics/cli.py
+++ b/srcopsmetrics/cli.py
@@ -97,7 +97,8 @@ def cli(
         )
 
     if visualize_statistics:
-        visualize_project_results(project=project, is_local=is_local)
+        for project in repos:
+            visualize_project_results(project=project, is_local=is_local)
 
     if reviewer_reccomender:
         reviewer_assigner = ReviewerAssigner()

--- a/srcopsmetrics/cli.py
+++ b/srcopsmetrics/cli.py
@@ -32,6 +32,7 @@ logging.basicConfig(level=logging.INFO)
 
 _GITHUB_ACCESS_TOKEN = os.getenv("GITHUB_ACCESS_TOKEN")
 
+
 @click.command()
 @click.option(
     "--repository",
@@ -80,7 +81,7 @@ def cli(
     """Command Line Interface for SrcOpsMetrics."""
     repos = []
     gh = Github(login_or_token=_GITHUB_ACCESS_TOKEN, timeout=50)
-    
+
     if repository is not None:
         repos.append(gh.get_repo(repository).full_name)
 

--- a/srcopsmetrics/cli.py
+++ b/srcopsmetrics/cli.py
@@ -26,12 +26,9 @@ from srcopsmetrics.bot_knowledge import visualize_project_results
 from srcopsmetrics.github_knowledge import GitHubKnowledge
 from srcopsmetrics.evaluate_scores import ReviewerAssigner
 
-from github import Github
 
 _LOGGER = logging.getLogger("aicoe-src-ops-metrics")
 logging.basicConfig(level=logging.INFO)
-
-_GITHUB_ACCESS_TOKEN = os.getenv("GITHUB_ACCESS_TOKEN")
 
 
 @click.command()

--- a/srcopsmetrics/cli.py
+++ b/srcopsmetrics/cli.py
@@ -35,8 +35,22 @@ logging.basicConfig(level=logging.INFO)
     "--project",
     "-p",
     type=str,
-    required=True,
-    help="Project to be analyzed (e.g thoth-station/performance).",
+    required=False,
+    help="All repositories of a Project to be analyzed (e.g thoth-station)",
+)
+@click.option(
+    "--repository",
+    "-r",
+    type=str,
+    required=False,
+    help="Repository to be analysed (e.g thoth-station/performance)",
+)
+@click.option(
+    "--organization",
+    "-o",
+    type=str,
+    required=False,
+    help="All repositories of an Organization to be analysed",
 )
 @click.option(
     "--create-knowledge",
@@ -58,16 +72,27 @@ logging.basicConfig(level=logging.INFO)
     help="Visualize statistics on the project repository knowledge collected.",
 )
 @click.option(
-    "--reviewer-reccomender", "-r", is_flag=True, help="Assign reviewers based on previous knowledge collected."
+    "--reviewer-reccomender", "-R", is_flag=True, help="Assign reviewers based on previous knowledge collected."
 )
 def cli(
     project: str,
+    repository: str,
+    organization: str,
     create_knowledge: bool,
     is_local: bool,
     visualize_statistics: bool,
     reviewer_reccomender: bool
 ):
     """Command Line Interface for SrcOpsMetrics."""
+    projects = [] if project not None else projects 
+
+    for proj in repository:
+        projec.append(proj.fullname)
+    
+    for repo in organization:
+        for proj in repo:
+            projec.append(proj.fullname)
+
     if create_knowledge:
         projects = project.split(',')
         analyse_projects(

--- a/srcopsmetrics/cli.py
+++ b/srcopsmetrics/cli.py
@@ -88,13 +88,13 @@ def cli(
             is_local=is_local
         )
 
-    if visualize_statistics:
-        for project in repos:
+    for project in repos:
+        if visualize_statistics:
             visualize_project_results(project=project, is_local=is_local)
 
-    if reviewer_reccomender:
-        reviewer_assigner = ReviewerAssigner()
-        reviewer_assigner.evaluate_reviewers_scores(project=project, is_local=is_local)
+        if reviewer_reccomender:
+            reviewer_assigner = ReviewerAssigner()
+            reviewer_assigner.evaluate_reviewers_scores(project=project, is_local=is_local)
 
 
 if __name__ == "__main__":

--- a/srcopsmetrics/cli.py
+++ b/srcopsmetrics/cli.py
@@ -23,8 +23,8 @@ import os
 
 from srcopsmetrics.bot_knowledge import analyse_projects
 from srcopsmetrics.bot_knowledge import visualize_project_results
+from srcopsmetrics.github_knowledge import GitHubKnowledge
 from srcopsmetrics.evaluate_scores import ReviewerAssigner
-from srcopsmetrics.utils import get_repositories
 
 from github import Github
 
@@ -81,7 +81,7 @@ def cli(
     reviewer_reccomender: bool
 ):
     """Command Line Interface for SrcOpsMetrics."""
-    repos = get_repositories(repository=repository, organization=organization)
+    repos = GitHubKnowledge.get_repositories(repository=repository, organization=organization)
     if create_knowledge:
         analyse_projects(
             projects=[repo.split("/") for repo in repos],

--- a/srcopsmetrics/cli.py
+++ b/srcopsmetrics/cli.py
@@ -24,6 +24,7 @@ import os
 from srcopsmetrics.bot_knowledge import analyse_projects
 from srcopsmetrics.bot_knowledge import visualize_project_results
 from srcopsmetrics.evaluate_scores import ReviewerAssigner
+from srcopsmetrics.utils import get_repositories
 
 from github import Github
 
@@ -79,17 +80,7 @@ def cli(
     reviewer_reccomender: bool
 ):
     """Command Line Interface for SrcOpsMetrics."""
-    repos = []
-    gh = Github(login_or_token=_GITHUB_ACCESS_TOKEN, timeout=50)
-
-    if repository is not None:
-        repos.append(gh.get_repo(repository).full_name)
-
-    if organization is not None:
-        for r in gh.get_organization(organization).get_repos():
-            repos.append(r.full_name)
-
-    _LOGGER.info("Overall repositories found: %d" % len(repos))
+    repos = get_repositories(repository=repository, organization=organization)
     if create_knowledge:
         analyse_projects(
             projects=[repo.split("/") for repo in repos],

--- a/srcopsmetrics/github_knowledge.py
+++ b/srcopsmetrics/github_knowledge.py
@@ -73,6 +73,28 @@ class GitHubKnowledge:
         return repo
 
     @staticmethod
+    def get_repositories(repository: str = None, organization: str = None) -> List[str]:
+        """Get overall repositories to be inspected.
+
+        :param repository:str:
+        :param organization:str:
+
+        :rtype: List of all repositories (repository + repositories in organization)
+        """
+        repos = []
+        gh = Github(login_or_token=_GITHUB_ACCESS_TOKEN, timeout=50)
+
+        if repository is not None:
+            repos.append(gh.get_repo(repository).full_name)
+
+        if organization is not None:
+            for r in gh.get_organization(organization).get_repos():
+                repos.append(r.full_name)
+
+        _LOGGER.info("Overall repositories found: %d" % len(repos))
+        return repos
+
+    @staticmethod
     def assign_pull_request_size(lines_changes: int) -> str:
         """Assign size of PR is label is not provided."""
         if lines_changes > 1000:

--- a/srcopsmetrics/github_knowledge.py
+++ b/srcopsmetrics/github_knowledge.py
@@ -88,7 +88,10 @@ class GitHubKnowledge:
             repos.append(gh.get_repo(repository).full_name)
 
         if organization is not None:
-            for r in gh.get_organization(organization).get_repos():
+            repositories = gh.get_organization(organization).get_repos()
+            if repositories.totalCount == 0:
+                _LOGGER.warn("Organization does not contain any repository")
+            for r in repositories:
                 repos.append(r.full_name)
 
         _LOGGER.info("Overall repositories found: %d" % len(repos))

--- a/srcopsmetrics/utils.py
+++ b/srcopsmetrics/utils.py
@@ -25,7 +25,6 @@ import numpy as np
 from typing import Tuple
 from pathlib import Path
 
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/srcopsmetrics/utils.py
+++ b/srcopsmetrics/utils.py
@@ -22,8 +22,10 @@ import os
 
 import numpy as np
 
-from typing import Tuple
+from typing import Tuple, List
 from pathlib import Path
+from github import Github
+from github_knowledge import _GITHUB_ACCESS_TOKEN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -96,3 +98,25 @@ def convert_num2label(score: float) -> Tuple[str, float]:
         _LOGGER.error("%s cannot be mapped, it's out of range [%f, %f]." % (score, 0.01, 0.9))
 
     return pull_request_size, assigned_score
+
+
+def get_repositories(repository: str = None, organization: str = None) -> List[str]:
+    """Get overall repositories to be inspected
+
+    :param repository:str:
+    :param organization:str:
+
+    :rtype: List of all repositories (repository + repositories in organization)
+    """
+    repos = []
+    gh = Github(login_or_token=_GITHUB_ACCESS_TOKEN, timeout=50)
+
+    if repository is not None:
+        repos.append(gh.get_repo(repository).full_name)
+
+    if organization is not None:
+        for r in gh.get_organization(organization).get_repos():
+            repos.append(r.full_name)
+
+    _LOGGER.info("Overall repositories found: %d" % len(repos))
+    return repos

--- a/srcopsmetrics/utils.py
+++ b/srcopsmetrics/utils.py
@@ -101,7 +101,7 @@ def convert_num2label(score: float) -> Tuple[str, float]:
 
 
 def get_repositories(repository: str = None, organization: str = None) -> List[str]:
-    """Get overall repositories to be inspected
+    """Get overall repositories to be inspected.
 
     :param repository:str:
     :param organization:str:

--- a/srcopsmetrics/utils.py
+++ b/srcopsmetrics/utils.py
@@ -24,8 +24,7 @@ import numpy as np
 
 from typing import Tuple, List
 from pathlib import Path
-from github import Github
-from github_knowledge import _GITHUB_ACCESS_TOKEN
+
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/srcopsmetrics/utils.py
+++ b/srcopsmetrics/utils.py
@@ -22,7 +22,7 @@ import os
 
 import numpy as np
 
-from typing import Tuple, List
+from typing import Tuple
 from pathlib import Path
 
 

--- a/srcopsmetrics/utils.py
+++ b/srcopsmetrics/utils.py
@@ -98,25 +98,3 @@ def convert_num2label(score: float) -> Tuple[str, float]:
         _LOGGER.error("%s cannot be mapped, it's out of range [%f, %f]." % (score, 0.01, 0.9))
 
     return pull_request_size, assigned_score
-
-
-def get_repositories(repository: str = None, organization: str = None) -> List[str]:
-    """Get overall repositories to be inspected.
-
-    :param repository:str:
-    :param organization:str:
-
-    :rtype: List of all repositories (repository + repositories in organization)
-    """
-    repos = []
-    gh = Github(login_or_token=_GITHUB_ACCESS_TOKEN, timeout=50)
-
-    if repository is not None:
-        repos.append(gh.get_repo(repository).full_name)
-
-    if organization is not None:
-        for r in gh.get_organization(organization).get_repos():
-            repos.append(r.full_name)
-
-    _LOGGER.info("Overall repositories found: %d" % len(repos))
-    return repos


### PR DESCRIPTION
## This introduces a breaking change

- [ ] Yes
- [ X ] No

## Description

There was a major misunderstanding of what project means in cli.
Now it is implemented to be valid with GitHub's terminology, that means:
- option project was changed to option *repository*
- option organization added to cli -> this allows to only specify the name of the organisation, from which all of the repositories will be inspected