### PR TITLE
store issue ids as str in dict

### DIFF
--- a/srcopsmetrics/github_knowledge.py
+++ b/srcopsmetrics/github_knowledge.py
@@ -214,7 +214,7 @@ class GitHubKnowledge:
 
         labels = [label.name for label in issue.get_labels()]
 
-        data[issue.number] = {
+        data[str(issue.number)] = {
             "created_by": issue.user.login,
             "created_at": issue.created_at.timestamp(),
             "closed_by": issue.closed_by.login,


### PR DESCRIPTION
## This introduces a breaking change

- [ ] Yes
- [X] No

Issues were stored with their IDs as an *int key* in dictionary, and when storing to ceph - they were probably automatically converted to strings. The problem occurred when new knowledge had to be stored - it contained old knowledge (string ids) and a new one (int ids), which raised an exception in thoth.storages.