### PR TITLE
Implement feature

### DIFF
--- a/srcopsmetrics/bot_knowledge.py
+++ b/srcopsmetrics/bot_knowledge.py
@@ -17,20 +17,17 @@
 
 """Create, Visualize, Use bot knowledge from different Software Development Platforms."""
 
+import json
 import logging
 import os
-import json
-
-from typing import List
-from typing import Tuple
-
 from pathlib import Path
+from typing import List, Optional, Tuple
 
 from srcopsmetrics.enums import EntityTypeEnum
 from srcopsmetrics.github_knowledge import GitHubKnowledge
 from srcopsmetrics.pre_processing import PreProcessing
-from srcopsmetrics.visualization import Visualization
 from srcopsmetrics.utils import check_directory
+from srcopsmetrics.visualization import Visualization
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,7 +36,9 @@ pre_processing = PreProcessing()
 visualization = Visualization()
 
 
-def analyse_projects(projects: List[Tuple[str, str]], is_local: bool = False) -> None:
+def analyse_projects(
+    projects: List[Tuple[str, str]], is_local: bool = False, entities: Optional[List[str]] = None
+) -> None:
     """Run Issues (that are not PRs), PRs, PR Reviews analysis on specified projects.
 
     Arguments:
@@ -52,6 +51,12 @@ def analyse_projects(projects: List[Tuple[str, str]], is_local: bool = False) ->
 
         project_path = path.joinpath("./" + github_repo.full_name)
         check_directory(project_path)
+
+        if entities is not None:
+            for entity in entities:
+                _LOGGER.info("%s inspection" % entity)
+                github_knowledge.analyse_entity(github_repo, project_path, entity, is_local)
+            continue
 
         _LOGGER.info("Issues inspection")
         github_knowledge.analyse_entity(github_repo, project_path, EntityTypeEnum.ISSUE.value, is_local)

--- a/srcopsmetrics/cli.py
+++ b/srcopsmetrics/cli.py
@@ -18,16 +18,16 @@
 """This is the CLI for SrcOpsMetrics to create, visualize, use bot knowledge."""
 
 import logging
-import click
 import os
+from typing import List, Optional
 
-from typing import Optional
+import click
 
-from srcopsmetrics.bot_knowledge import analyse_projects
-from srcopsmetrics.bot_knowledge import visualize_project_results
-from srcopsmetrics.github_knowledge import GitHubKnowledge
+from srcopsmetrics.bot_knowledge import (analyse_projects,
+                                         visualize_project_results)
+from srcopsmetrics.enums import EntityTypeEnum
 from srcopsmetrics.evaluate_scores import ReviewerAssigner
-
+from srcopsmetrics.github_knowledge import GitHubKnowledge
 
 _LOGGER = logging.getLogger("aicoe-src-ops-metrics")
 logging.basicConfig(level=logging.INFO)
@@ -51,7 +51,6 @@ logging.basicConfig(level=logging.INFO)
 @click.option(
     "--create-knowledge",
     "-c",
-    envvar="CREATE_KNOWLEDGE",
     is_flag=True,
     help="Create knowledge from a project repository.",
 )
@@ -61,7 +60,15 @@ logging.basicConfig(level=logging.INFO)
     is_flag=True,
     help="Use local for knowledge loading and storing.",
 )
-@click.option("--create-knowledge", "-c", is_flag=True, help="Create knowledge from a project repository.")
+@click.option(
+    "--entities",
+    "-e",
+    multiple=True,
+    type=str,
+    required=False,
+    help="""Entities to be analysed (e.g thoth-station/performance)
+            If not specified, all entities will be analysed""",
+)
 @click.option(
     "--visualize-statistics",
     "-v",
@@ -76,15 +83,17 @@ def cli(
     organization: Optional[str],
     create_knowledge: bool,
     is_local: bool,
+    entities: Optional[List[str]],
     visualize_statistics: bool,
-    reviewer_reccomender: bool
+    reviewer_reccomender: bool,
 ):
     """Command Line Interface for SrcOpsMetrics."""
     repos = GitHubKnowledge.get_repositories(repository=repository, organization=organization)
     if create_knowledge:
         analyse_projects(
             projects=[repo.split("/") for repo in repos],
-            is_local=is_local
+            is_local=is_local,
+            entities=entities
         )
 
     for project in repos:


### PR DESCRIPTION
## This introduces a breaking change

- [ ] Yes
- [X] No

## Description

Entities that will be inspected can now be specified. If not specified, all of the implemented entities will be used.

When working with cli, just add **-e** option followed by the entity name. If multiple entities are desired, specify each by the new **-e** option, e.g.:
```srcopsmetrics.cli -clo AICoE -e Issue -e ContentFile```

When working with ```bot_knowledge``` module, just pass a new argument in form of string List.
